### PR TITLE
spring-security-lti13 version 0.0.4 requires kid in JWT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>uk.ac.ox.ctl</groupId>
             <artifactId>spring-security-lti13</artifactId>
-            <version>0.0.3</version>
+            <version>0.0.4</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/src/main/java/uk/ac/ox/ctl/lti13/demo/Lti13Configuration.java
+++ b/src/main/java/uk/ac/ox/ctl/lti13/demo/Lti13Configuration.java
@@ -59,7 +59,7 @@ public class Lti13Configuration {
 
     @Bean
     public KeyPairService keyPairService(KeyPair keyPair) {
-        return new SingleKeyPairService(keyPair);
+        return new SingleKeyPairService(keyPair, jwtId);
     }
 
     @Bean


### PR DESCRIPTION
Dependency spring-security-lti13 version 0.0.4 requires JWT to have `kid`, see https://github.com/oxctl/spring-security-lti13/pull/18.