### PR TITLE
Updated WebSecurityConfig to avoid using deprecated http.apply() method

### DIFF
--- a/src/main/java/uk/ac/ox/ctl/lti13/demo/WebSecurityConfig.java
+++ b/src/main/java/uk/ac/ox/ctl/lti13/demo/WebSecurityConfig.java
@@ -20,9 +20,9 @@ public class WebSecurityConfig {
                     "/config.json", "/.well-known/jwks.json", "/error").permitAll();
             authorizeHttpRequestsCustomizer.anyRequest().authenticated();
         });
-        Lti13Configurer lti13Configurer = new Lti13Configurer();
-        lti13Configurer.setSecurityContextRepository(new HttpSessionSecurityContextRepository());
-        http.apply(lti13Configurer);
+        http.with(new Lti13Configurer(), lti13Configurer -> lti13Configurer
+                .setSecurityContextRepository(new HttpSessionSecurityContextRepository())
+        );
         return http.build();
     }
 


### PR DESCRIPTION
I noticed a warning on the use of the deprecated method http.apply() probably after the introduction of Spring Boot 3.x and since spring security 6.2 as shown on the screenshot below, using http.with() is a working alternative for this.


<img width="500" alt="Screenshot 2025-04-08 at 10 41 11 am" src="https://github.com/user-attachments/assets/18db70c4-c995-41f1-9253-22f2061ac5b2" />

More info at [Spring Docs here](https://docs.spring.io/spring-security/reference/api/java/org/springframework/security/config/annotation/AbstractConfiguredSecurityBuilder.html#apply(C))
